### PR TITLE
Refactor: 여정 Request 상속 매핑 수정

### DIFF
--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/controller/ItineraryController.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/controller/ItineraryController.java
@@ -1,7 +1,13 @@
 package com.example.trip_itinerary.itinerary.controller;
 
+import com.example.trip_itinerary.itinerary.dto.request.save.AccommodationSaveRequest;
 import com.example.trip_itinerary.itinerary.dto.request.save.ItinerarySaveRequest;
+import com.example.trip_itinerary.itinerary.dto.request.save.StaySaveRequest;
+import com.example.trip_itinerary.itinerary.dto.request.save.TransportSaveRequest;
+import com.example.trip_itinerary.itinerary.dto.request.update.AccommodationPatchRequest;
 import com.example.trip_itinerary.itinerary.dto.request.update.ItineraryPatchRequest;
+import com.example.trip_itinerary.itinerary.dto.request.update.StayPatchRequest;
+import com.example.trip_itinerary.itinerary.dto.request.update.TransportPatchRequest;
 import com.example.trip_itinerary.itinerary.service.ItineraryService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,18 +26,46 @@ public class ItineraryController {
         this.itineraryService = itineraryService;
     }
 
-    @PostMapping("/{trip_id}/itinerary")
-    public ResponseEntity<Void> saveItinerary(@PathVariable(name = "trip_id") Long id, @RequestBody @Validated ItinerarySaveRequest staySaveRequest) {
-        itineraryService.saveItinerary(id, staySaveRequest);
+    @PostMapping("/{trip_id}/transport")
+    public ResponseEntity<Void> saveTransport(@PathVariable(name = "trip_id") Long id, @RequestBody @Validated TransportSaveRequest transportSaveRequest) {
+        itineraryService.saveTransport(id, transportSaveRequest);
 
-        return ResponseEntity.created(URI.create("/trips/" + id + "/itinerary")).build();
+        return ResponseEntity.created(URI.create("/trips/" + id)).build();
     }
 
-    @PatchMapping("/{trip_id}/itineraries/{itinerary_id}")
-    public ResponseEntity<HttpStatus> patchItinerary(@PathVariable(name = "itinerary_id") Long id, @RequestBody @Validated ItineraryPatchRequest itineraryPatchRequest) {
-        itineraryService.patchItinerary(id, itineraryPatchRequest);
+    @PostMapping("/{trip_id}/stay")
+    public ResponseEntity<Void> saveTransport(@PathVariable(name = "trip_id") Long id, @RequestBody @Validated StaySaveRequest staySaveRequest) {
+        itineraryService.saveStay(id, staySaveRequest);
 
-        return ResponseEntity.created(URI.create("/trips/" + id + "/itineraries/" + id)).build(); // TODO : id부분 tripId, itineraryId로 변경해야 함
+        return ResponseEntity.created(URI.create("/trips/" + id)).build();
     }
+
+    @PostMapping("/{trip_id}/accommodation")
+    public ResponseEntity<Void> saveAccommodation(@PathVariable(name = "trip_id") Long id, @RequestBody @Validated AccommodationSaveRequest accommodationSaveRequest) {
+        itineraryService.saveAccommodation(id, accommodationSaveRequest);
+
+        return ResponseEntity.created(URI.create("/trips/" + id)).build();
+    }
+
+    @PatchMapping("/{trip_id}/transport/{itinerary_id}")
+    public ResponseEntity<Void> patchTransport(@PathVariable(name = "itinerary_id") Long id, @RequestBody @Validated TransportPatchRequest transportPatchRequest) {
+        Long tripId = itineraryService.patchTransport(id, transportPatchRequest);
+
+        return ResponseEntity.created(URI.create("/trips/" + tripId)).build();
+    }
+    @PatchMapping("/{trip_id}/stay/{itinerary_id}")
+    public ResponseEntity<Void> patchStay(@PathVariable(name = "itinerary_id") Long id, @RequestBody @Validated StayPatchRequest stayPatchRequest) {
+        Long tripId = itineraryService.patchStay(id, stayPatchRequest);
+
+        return ResponseEntity.created(URI.create("/trips/" + tripId)).build();
+    }
+    @PatchMapping("/{trip_id}/accommodation/{itinerary_id}")
+    public ResponseEntity<Void> patchAccommodation(@PathVariable(name = "itinerary_id") Long id, @RequestBody @Validated AccommodationPatchRequest accommodationPatchRequest) {
+        Long tripId = itineraryService.patchAccommodation(id, accommodationPatchRequest);
+
+        return ResponseEntity.created(URI.create("/trips/" + tripId)).build();
+    }
+
+
 
 }

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/save/ItinerarySaveRequest.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/save/ItinerarySaveRequest.java
@@ -11,11 +11,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({
-        @JsonSubTypes.Type(value = StaySaveRequest.class, name = "stay"),
-        @JsonSubTypes.Type(value = TransportSaveRequest.class, name = "transport"),
-        @JsonSubTypes.Type(value = AccommodationSaveRequest.class, name = "accommodation")
-})
 public class ItinerarySaveRequest {
 
     @NotBlank(message = "여정 이름을 입력해주세요.")

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/update/ItineraryPatchRequest.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/update/ItineraryPatchRequest.java
@@ -10,11 +10,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({
-        @JsonSubTypes.Type(value = StayPatchRequest.class, name = "stay"),
-        @JsonSubTypes.Type(value = TransportPatchRequest.class, name = "transport"),
-        @JsonSubTypes.Type(value = AccommodationPatchRequest.class, name = "accommodation")
-})
 public class ItineraryPatchRequest {
 
     @Size(max = 30, message = "여정 이름은 최대 30자입니다.")

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/service/ItineraryService.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/service/ItineraryService.java
@@ -42,7 +42,7 @@ public class ItineraryService {
         this.itineraryTimeValidationService = itineraryTimeValidationService;
     }
 
-    public Transport saveTransport(Long id, TransportSaveRequest request) {
+    public void saveTransport(Long id, TransportSaveRequest request) {
         Trip foundTrip = tripRepository.findById(id).orElseThrow(() -> new TripNotFoundException(TripErrorCode.TRIP_NOT_FOUND));
         itineraryTimeValidationService.validateTransportSaveTimeRange(request, foundTrip);
 
@@ -50,48 +50,58 @@ public class ItineraryService {
                 request.getArrivalLocation(), DateUtil.toLocalDateTime(request.getDepartureDateTime()),
                 DateUtil.toLocalDateTime(request.getArrivalDateTime()));
 
-        return itineraryRepository.save(transport);
+        itineraryRepository.save(transport);
     }
 
-    public Accommodation saveAccommodation(Long id, AccommodationSaveRequest request) {
+    public void saveAccommodation(Long id, AccommodationSaveRequest request) {
         Trip foundTrip = tripRepository.findById(id).orElseThrow(() -> new TripNotFoundException(TripErrorCode.TRIP_NOT_FOUND));
         itineraryTimeValidationService.validateAccommodationSaveTimeRange(request, foundTrip);
 
         Accommodation accommodation = Accommodation.of(request.getName(), foundTrip, request.getAccommodationName(),
                 DateUtil.toLocalDateTime(request.getCheckInTime()), DateUtil.toLocalDateTime(request.getCheckOutTime()));
-        return itineraryRepository.save(accommodation);
+
+        itineraryRepository.save(accommodation);
     }
 
-    public Stay saveStay(Long id, StaySaveRequest request) {
+    public void saveStay(Long id, StaySaveRequest request) {
         Trip foundTrip = tripRepository.findById(id).orElseThrow(() -> new TripNotFoundException(TripErrorCode.TRIP_NOT_FOUND));
         itineraryTimeValidationService.validateStaySaveTimeRange(request, foundTrip);
 
         Stay stay = Stay.of(request.getName(), foundTrip, request.getLocation(), DateUtil.toLocalDateTime(request.getArrivalDateTime()),
                 DateUtil.toLocalDateTime(request.getLeaveDateTime()));
-        return itineraryRepository.save(stay);
+        itineraryRepository.save(stay);
     }
 
-    public void patchTransport(Transport transport, TransportPatchRequest request) {
-        Itinerary foundItinerary = itineraryRepository.findById(id).orElseThrow(() -> new ItineraryNotFoundException(ItineraryErrorCode.ITINERARY_NOT_FOUND));
-        itineraryTimeValidationService.validateTransportPatchTimeRange(request, transport.getTrip());
+    public Long patchTransport(Long id, TransportPatchRequest request) {
+        Transport foundTransport = (Transport) itineraryRepository.findById(id).orElseThrow(() -> new ItineraryNotFoundException(ItineraryErrorCode.ITINERARY_NOT_FOUND));
+        itineraryTimeValidationService.validateTransportPatchTimeRange(request, foundTransport.getTrip());
 
-        transport.updateTransport(request.getName(), request.getTransportation(),
+        foundTransport.updateTransport(request.getName(), request.getTransportation(),
                 request.getDepartureLocation(), request.getArrivalLocation(),
                 DateUtil.toLocalDateTime(request.getDepartureDateTime()), DateUtil.toLocalDateTime(request.getArrivalDateTime()));
+
+        return foundTransport.getTrip().getId();
     }
 
-    public void patchAccommodation(Accommodation accommodation, AccommodationPatchRequest request) {
-        itineraryTimeValidationService.validateAccommodationPatchTimeRange(request, accommodation.getTrip());
+    public Long patchAccommodation(Long id, AccommodationPatchRequest request) {
+        Accommodation foundAccommodation = (Accommodation) itineraryRepository.findById(id).orElseThrow(() -> new ItineraryNotFoundException(ItineraryErrorCode.ITINERARY_NOT_FOUND));
+        itineraryTimeValidationService.validateAccommodationPatchTimeRange(request, foundAccommodation.getTrip());
 
-        accommodation.updateAccommodation(request.getName(), request.getAccommodationName(),
+        foundAccommodation.updateAccommodation(request.getName(), request.getAccommodationName(),
                 DateUtil.toLocalDateTime(request.getCheckInTime()), DateUtil.toLocalDateTime(request.getCheckOutTime()));
+
+        return foundAccommodation.getTrip().getId();
     }
 
-    public void patchStay(Stay stay, StayPatchRequest request) {
-        itineraryTimeValidationService.validateStayPatchTimeRange(request, stay.getTrip());
+    public Long patchStay(Long id, StayPatchRequest request) {
+        Stay foundStay = (Stay) itineraryRepository.findById(id).orElseThrow(() -> new ItineraryNotFoundException(ItineraryErrorCode.ITINERARY_NOT_FOUND));
 
-        stay.updateStay(request.getName(), request.getLocation(),
+        itineraryTimeValidationService.validateStayPatchTimeRange(request, foundStay.getTrip());
+
+        foundStay.updateStay(request.getName(), request.getLocation(),
                 DateUtil.toLocalDateTime(request.getArrivalDateTime()), DateUtil.toLocalDateTime(request.getLeaveDateTime()));
+
+        return foundStay.getTrip().getId();
     }
 
 }

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/trip/controller/TripController.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/trip/controller/TripController.java
@@ -25,7 +25,7 @@ public class TripController {
     }
 
     @PostMapping
-    public ResponseEntity<HttpStatus> saveTrip(@RequestBody @Validated TripSaveRequest tripSaveRequest) {
+    public ResponseEntity<Void> saveTrip(@RequestBody @Validated TripSaveRequest tripSaveRequest) {
         tripService.saveTrip(tripSaveRequest);
 
         return ResponseEntity.created(URI.create("/trips")).build();
@@ -46,7 +46,7 @@ public class TripController {
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<HttpStatus> updateTripById(@PathVariable Long id, @RequestBody @Validated TripPatchRequest tripPatchRequest) {
+    public ResponseEntity<Void> updateTripById(@PathVariable Long id, @RequestBody @Validated TripPatchRequest tripPatchRequest) {
         tripService.updateTrip(id, tripPatchRequest);
 
         return ResponseEntity.created(URI.create("/trips" + id)).build();

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/trip/domain/Trip.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/trip/domain/Trip.java
@@ -31,6 +31,10 @@ public class Trip {
     @OneToMany(mappedBy = "trip", cascade = CascadeType.REMOVE)
     private List<Itinerary> itineraryList = new ArrayList<>();
 
+    public List<Itinerary> getItineraryList() {
+        return itineraryList;
+    }
+
     protected Trip() {
     }
 


### PR DESCRIPTION
## 목적
여정 Request의 상속관계를 이용한 Controller 메서드 매핑을 없애기 위함

## 핵심 변경사항
여정의 save, update 의 Requst 수정, controller 수정

## 특이 사항 

## Issue Link - #4

## Reference
