### PR TITLE
#22 카카오 API로 상세주소 전달기능 추가

### DIFF
--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/controller/ItineraryController.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/controller/ItineraryController.java
@@ -1,14 +1,13 @@
 package com.example.trip_itinerary.itinerary.controller;
 
 import com.example.trip_itinerary.itinerary.dto.request.save.ItinerarySaveRequest;
-import com.example.trip_itinerary.itinerary.dto.request.save.StaySaveRequest;
 import com.example.trip_itinerary.itinerary.dto.request.update.ItineraryPatchRequest;
+import com.example.trip_itinerary.itinerary.dto.response.KakaoAddressResponse;
 import com.example.trip_itinerary.itinerary.service.ItineraryService;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/trips")
 public class ItineraryController {
 
     private final ItineraryService itineraryService;
@@ -17,12 +16,17 @@ public class ItineraryController {
         this.itineraryService = itineraryService;
     }
 
-    @PostMapping("/{trip_id}/itinerary")
-    public Long saveItinerary(@PathVariable(name = "trip_id") Long id, @RequestBody @Validated ItinerarySaveRequest staySaveRequest) {
-        return itineraryService.saveItinerary(id, staySaveRequest);
+    @GetMapping("/address")
+    public KakaoAddressResponse getAddressByNameFromKakao(@RequestParam(name= "query") String query){
+        return itineraryService.getAddressByNameFromKakao(query);
     }
 
-    @PatchMapping("/itineraries/{itinerary_id}")
+    @PostMapping("/trips/{trip_id}/itinerary")
+    public Long saveItinerary(@PathVariable(name = "trip_id") Long id, @RequestBody @Validated ItinerarySaveRequest staySaveRequest) {
+        return itineraryService.saveTransport(id, staySaveRequest);
+    }
+
+    @PatchMapping("/trips/itineraries/{itinerary_id}")
     public Long patchItinerary(@PathVariable(name = "itinerary_id") Long id, @RequestBody @Validated ItineraryPatchRequest itineraryPatchRequest) {
         return itineraryService.patchItinerary(id, itineraryPatchRequest);
     }

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/domain/Accommodation.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/domain/Accommodation.java
@@ -14,6 +14,9 @@ public class Accommodation extends Itinerary {
     @Column(name = "accommodation_name", nullable = false, length = 30)
     private String accommodationName;
 
+    @Column(name = "road_address", nullable = false, length = 30)
+    private String roadAddress;
+
     @Column(name = "check_in_time", nullable = false)
     private LocalDateTime checkInTime;
 
@@ -23,22 +26,29 @@ public class Accommodation extends Itinerary {
     protected Accommodation() {
     }
 
-    private Accommodation(String name, Trip trip, String accommodationName, LocalDateTime checkInTime, LocalDateTime checkOutTime) {
+    private Accommodation(String name, Trip trip, String accommodationName, String roadAddress, LocalDateTime checkInTime, LocalDateTime checkOutTime) {
         super(name, trip);
         this.accommodationName = accommodationName;
+        this.roadAddress = roadAddress;
         this.checkInTime = checkInTime;
         this.checkOutTime = checkOutTime;
     }
 
-    public static Accommodation of(String name, Trip trip, String accommodationName, LocalDateTime checkInTime, LocalDateTime checkOutTime) {
-        return new Accommodation(name, trip, accommodationName, checkInTime, checkOutTime);
+    public static Accommodation of(String name, Trip trip, String accommodationName,String roadAddress,
+                                   LocalDateTime checkInTime, LocalDateTime checkOutTime) {
+        return new Accommodation(name, trip, accommodationName, roadAddress, checkInTime, checkOutTime);
     }
 
-    public void updateAccommodation(String name, String accommodationName, LocalDateTime checkInTime, LocalDateTime checkOutTime) {
+    public void updateAccommodation(String name, String accommodationName, String roadAddress, LocalDateTime checkInTime, LocalDateTime checkOutTime) {
         super.updateItinerary(name);
         this.accommodationName = accommodationName;
+        this.roadAddress = roadAddress;
         this.checkInTime = checkInTime;
         this.checkOutTime = checkOutTime;
+    }
+
+    public String getRoadAddress() {
+        return roadAddress;
     }
 
     public String getAccommodationName() {

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/domain/Accommodation.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/domain/Accommodation.java
@@ -14,8 +14,8 @@ public class Accommodation extends Itinerary {
     @Column(name = "accommodation_name", nullable = false, length = 30)
     private String accommodationName;
 
-    @Column(name = "road_address", nullable = false, length = 30)
-    private String roadAddress;
+    @Column(name = "accommodation_address", nullable = false, length = 50)
+    private String accommodationAddress;
 
     @Column(name = "check_in_time", nullable = false)
     private LocalDateTime checkInTime;
@@ -26,29 +26,29 @@ public class Accommodation extends Itinerary {
     protected Accommodation() {
     }
 
-    private Accommodation(String name, Trip trip, String accommodationName, String roadAddress, LocalDateTime checkInTime, LocalDateTime checkOutTime) {
+    private Accommodation(String name, Trip trip, String accommodationName, String accommodationAddress, LocalDateTime checkInTime, LocalDateTime checkOutTime) {
         super(name, trip);
         this.accommodationName = accommodationName;
-        this.roadAddress = roadAddress;
+        this.accommodationAddress = accommodationAddress;
         this.checkInTime = checkInTime;
         this.checkOutTime = checkOutTime;
     }
 
-    public static Accommodation of(String name, Trip trip, String accommodationName,String roadAddress,
+    public static Accommodation of(String name, Trip trip, String accommodationName,String accommodationAddress,
                                    LocalDateTime checkInTime, LocalDateTime checkOutTime) {
-        return new Accommodation(name, trip, accommodationName, roadAddress, checkInTime, checkOutTime);
+        return new Accommodation(name, trip, accommodationName, accommodationAddress, checkInTime, checkOutTime);
     }
 
-    public void updateAccommodation(String name, String accommodationName, String roadAddress, LocalDateTime checkInTime, LocalDateTime checkOutTime) {
+    public void updateAccommodation(String name, String accommodationName, String accommodationAddress, LocalDateTime checkInTime, LocalDateTime checkOutTime) {
         super.updateItinerary(name);
         this.accommodationName = accommodationName;
-        this.roadAddress = roadAddress;
+        this.accommodationAddress = accommodationAddress;
         this.checkInTime = checkInTime;
         this.checkOutTime = checkOutTime;
     }
 
-    public String getRoadAddress() {
-        return roadAddress;
+    public String getAccommodationAddress() {
+        return accommodationAddress;
     }
 
     public String getAccommodationName() {

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/domain/Stay.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/domain/Stay.java
@@ -14,8 +14,8 @@ public class Stay extends Itinerary {
     @Column(nullable = false, length = 30)
     private String location;
 
-    @Column(name = "road_address", nullable = false, length = 30)
-    private String roadAddress;
+    @Column(name = "location_address", nullable = false, length = 50)
+    private String locationAddress;
 
     @Column(nullable = false, name = "arrival_date_time")
     private LocalDateTime arrivalDateTime;
@@ -26,22 +26,22 @@ public class Stay extends Itinerary {
     protected Stay() {
     }
 
-    private Stay(String name, Trip trip, String location, String roadAddress, LocalDateTime arrivalDateTime, LocalDateTime leaveDateTime) {
+    private Stay(String name, Trip trip, String location, String locationAddress, LocalDateTime arrivalDateTime, LocalDateTime leaveDateTime) {
         super(name, trip);
         this.location = location;
-        this.roadAddress = roadAddress;
+        this.locationAddress = locationAddress;
         this.arrivalDateTime = arrivalDateTime;
         this.leaveDateTime = leaveDateTime;
     }
 
-    public static Stay of(String name, Trip trip, String location, String roadAddress, LocalDateTime arrivalDateTime, LocalDateTime leaveDateTime) {
-        return new Stay(name, trip, location, roadAddress, arrivalDateTime, leaveDateTime);
+    public static Stay of(String name, Trip trip, String location, String locationAddress, LocalDateTime arrivalDateTime, LocalDateTime leaveDateTime) {
+        return new Stay(name, trip, location, locationAddress, arrivalDateTime, leaveDateTime);
     }
 
-    public void updateStay(String name, String location, String roadAddress, LocalDateTime arrivalDateTime, LocalDateTime leaveDateTime) {
+    public void updateStay(String name, String location, String locationAddress, LocalDateTime arrivalDateTime, LocalDateTime leaveDateTime) {
         super.updateItinerary(name);
         this.location = location;
-        this.roadAddress = roadAddress;
+        this.locationAddress = locationAddress;
         this.arrivalDateTime = arrivalDateTime;
         this.leaveDateTime = leaveDateTime;
     }
@@ -50,8 +50,8 @@ public class Stay extends Itinerary {
         return location;
     }
 
-    public String getRoadAddress() {
-        return roadAddress;
+    public String getLocationAddress() {
+        return locationAddress;
     }
 
     public LocalDateTime getArrivalDateTime() {

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/domain/Stay.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/domain/Stay.java
@@ -14,6 +14,9 @@ public class Stay extends Itinerary {
     @Column(nullable = false, length = 30)
     private String location;
 
+    @Column(name = "road_address", nullable = false, length = 30)
+    private String roadAddress;
+
     @Column(nullable = false, name = "arrival_date_time")
     private LocalDateTime arrivalDateTime;
 
@@ -23,26 +26,32 @@ public class Stay extends Itinerary {
     protected Stay() {
     }
 
-    private Stay(String name, Trip trip, String location, LocalDateTime arrivalDateTime, LocalDateTime leaveDateTime) {
+    private Stay(String name, Trip trip, String location, String roadAddress, LocalDateTime arrivalDateTime, LocalDateTime leaveDateTime) {
         super(name, trip);
         this.location = location;
+        this.roadAddress = roadAddress;
         this.arrivalDateTime = arrivalDateTime;
         this.leaveDateTime = leaveDateTime;
     }
 
-    public static Stay of(String name, Trip trip, String location, LocalDateTime arrivalDateTime, LocalDateTime leaveDateTime) {
-        return new Stay(name, trip, location, arrivalDateTime, leaveDateTime);
+    public static Stay of(String name, Trip trip, String location, String roadAddress, LocalDateTime arrivalDateTime, LocalDateTime leaveDateTime) {
+        return new Stay(name, trip, location, roadAddress, arrivalDateTime, leaveDateTime);
     }
 
-    public void updateStay(String name, String location, LocalDateTime arrivalDateTime, LocalDateTime leaveDateTime) {
+    public void updateStay(String name, String location, String roadAddress, LocalDateTime arrivalDateTime, LocalDateTime leaveDateTime) {
         super.updateItinerary(name);
         this.location = location;
+        this.roadAddress = roadAddress;
         this.arrivalDateTime = arrivalDateTime;
         this.leaveDateTime = leaveDateTime;
     }
 
     public String getLocation() {
         return location;
+    }
+
+    public String getRoadAddress() {
+        return roadAddress;
     }
 
     public LocalDateTime getArrivalDateTime() {

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/domain/Transport.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/domain/Transport.java
@@ -17,14 +17,14 @@ public class Transport extends Itinerary {
     @Column(name = "departure_location", nullable = false, length = 30)
     private String departureLocation;
 
-    @Column(name = "departure_road_address", nullable = false, length = 30)
-    private String departureRoadAddress;
+    @Column(name = "departure_address", nullable = false, length = 30)
+    private String departureAddress;
 
     @Column(name = "arrival_location", nullable = false, length = 30)
     private String arrivalLocation;
 
-    @Column(name = "arrival_road_address", nullable = false, length = 30)
-    private String arrivalRoadAddress;
+    @Column(name = "arrival_address", nullable = false, length = 30)
+    private String arrivalAddress;
 
     @Column(name = "departure_date_time", nullable = false)
     private LocalDateTime departureDateTime;
@@ -36,34 +36,34 @@ public class Transport extends Itinerary {
     }
 
     private Transport(String name, Trip trip, String transportation, String departureLocation,
-                      String departureRoadAddress, String arrivalLocation,String arrivalRoadAddress,
+                      String departureAddress, String arrivalLocation,String arrivalAddress,
                       LocalDateTime departureDate, LocalDateTime arrivalDateTime) {
         super(name, trip);
         this.transportation = transportation;
         this.departureLocation = departureLocation;
-        this.departureRoadAddress = departureRoadAddress;
+        this.departureAddress = departureAddress;
         this.arrivalLocation = arrivalLocation;
-        this.arrivalRoadAddress = arrivalRoadAddress;
+        this.arrivalAddress = arrivalAddress;
         this.departureDateTime = departureDate;
         this.arrivalDateTime = arrivalDateTime;
     }
 
-    public static Transport of(String name, Trip trip, String transportation, String departureLocation, String arrivalLocation,
-                               String departureRoadAddress, String arrivalRoadAddress,
+    public static Transport of(String name, Trip trip, String transportation, String departureLocation,
+                               String departureAddress, String arrivalLocation, String arrivalAddress,
                                LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        return new Transport(name, trip, transportation, departureLocation, departureRoadAddress, arrivalLocation,arrivalRoadAddress, startDateTime, endDateTime);
+        return new Transport(name, trip, transportation, departureLocation, departureAddress, arrivalLocation,arrivalAddress, startDateTime, endDateTime);
     }
 
-    public void updateTransport(String name, String transportation, String departureLocation, String departureRoadAddress,
-                                String arrivalLocation, String arrivalRoadAddress,
+    public void updateTransport(String name, String transportation, String departureLocation, String departureAddress,
+                                String arrivalLocation, String arrivalAddress,
                                 LocalDateTime startDateTime, LocalDateTime endDateTime) {
 
         super.updateItinerary(name);
         this.transportation = transportation;
         this.departureLocation = departureLocation;
-        this.departureRoadAddress = departureRoadAddress;
+        this.departureAddress = departureAddress;
         this.arrivalLocation = arrivalLocation;
-        this.arrivalRoadAddress = arrivalRoadAddress;
+        this.arrivalAddress = arrivalAddress;
         this.departureDateTime = startDateTime;
         this.arrivalDateTime = endDateTime;
     }
@@ -72,12 +72,12 @@ public class Transport extends Itinerary {
         return transportation;
     }
 
-    public String getDepartureRoadAddress() {
-        return departureRoadAddress;
+    public String getDepartureAddress() {
+        return departureAddress;
     }
 
-    public String getArrivalRoadAddress() {
-        return arrivalRoadAddress;
+    public String getArrivalAddress() {
+        return arrivalAddress;
     }
 
     public String getDepartureLocation() {

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/domain/Transport.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/domain/Transport.java
@@ -17,8 +17,14 @@ public class Transport extends Itinerary {
     @Column(name = "departure_location", nullable = false, length = 30)
     private String departureLocation;
 
+    @Column(name = "departure_road_address", nullable = false, length = 30)
+    private String departureRoadAddress;
+
     @Column(name = "arrival_location", nullable = false, length = 30)
     private String arrivalLocation;
+
+    @Column(name = "arrival_road_address", nullable = false, length = 30)
+    private String arrivalRoadAddress;
 
     @Column(name = "departure_date_time", nullable = false)
     private LocalDateTime departureDateTime;
@@ -29,34 +35,49 @@ public class Transport extends Itinerary {
     protected Transport() {
     }
 
-    private Transport(String name, Trip trip, String transportation, String departureLocation, String arrivalLocation,
+    private Transport(String name, Trip trip, String transportation, String departureLocation,
+                      String departureRoadAddress, String arrivalLocation,String arrivalRoadAddress,
                       LocalDateTime departureDate, LocalDateTime arrivalDateTime) {
         super(name, trip);
         this.transportation = transportation;
         this.departureLocation = departureLocation;
+        this.departureRoadAddress = departureRoadAddress;
         this.arrivalLocation = arrivalLocation;
+        this.arrivalRoadAddress = arrivalRoadAddress;
         this.departureDateTime = departureDate;
         this.arrivalDateTime = arrivalDateTime;
     }
 
-    public static Transport of(String name, Trip trip, String transportation, String startLocation, String endLocation,
+    public static Transport of(String name, Trip trip, String transportation, String departureLocation, String arrivalLocation,
+                               String departureRoadAddress, String arrivalRoadAddress,
                                LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        return new Transport(name, trip, transportation, startLocation, endLocation, startDateTime, endDateTime);
+        return new Transport(name, trip, transportation, departureLocation, departureRoadAddress, arrivalLocation,arrivalRoadAddress, startDateTime, endDateTime);
     }
 
-    public void updateTransport(String name, String transportation, String startLocation,
-                                String endLocation, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+    public void updateTransport(String name, String transportation, String departureLocation, String departureRoadAddress,
+                                String arrivalLocation, String arrivalRoadAddress,
+                                LocalDateTime startDateTime, LocalDateTime endDateTime) {
 
         super.updateItinerary(name);
         this.transportation = transportation;
-        this.departureLocation = startLocation;
-        this.arrivalLocation = endLocation;
+        this.departureLocation = departureLocation;
+        this.departureRoadAddress = departureRoadAddress;
+        this.arrivalLocation = arrivalLocation;
+        this.arrivalRoadAddress = arrivalRoadAddress;
         this.departureDateTime = startDateTime;
         this.arrivalDateTime = endDateTime;
     }
 
     public String getTransportation() {
         return transportation;
+    }
+
+    public String getDepartureRoadAddress() {
+        return departureRoadAddress;
+    }
+
+    public String getArrivalRoadAddress() {
+        return arrivalRoadAddress;
     }
 
     public String getDepartureLocation() {

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/save/AccommodationSaveRequest.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/save/AccommodationSaveRequest.java
@@ -17,6 +17,10 @@ public class AccommodationSaveRequest extends ItinerarySaveRequest {
     @Size(max = 30, message = "숙소 이름은 최대 30자입니다.")
     private String accommodationName;
 
+    @NotBlank(message = "숙소 주소를 입력해주세요.")
+    @Size(max = 30, message = "숙소 주소는 최대 30자입니다.")
+    private String roadAddress;
+
     @NotNull(message = "체크인 시간을 입력해주세요.")
     private String checkInTime;
 

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/save/AccommodationSaveRequest.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/save/AccommodationSaveRequest.java
@@ -18,8 +18,8 @@ public class AccommodationSaveRequest extends ItinerarySaveRequest {
     private String accommodationName;
 
     @NotBlank(message = "숙소 주소를 입력해주세요.")
-    @Size(max = 30, message = "숙소 주소는 최대 30자입니다.")
-    private String roadAddress;
+    @Size(max = 50, message = "숙소 주소는 최대 50자입니다.")
+    private String accommodationAddress;
 
     @NotNull(message = "체크인 시간을 입력해주세요.")
     private String checkInTime;

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/save/StaySaveRequest.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/save/StaySaveRequest.java
@@ -18,6 +18,10 @@ public class StaySaveRequest extends ItinerarySaveRequest {
     @Size(max = 30, message = "체류 장소는 최대 30자입니다.")
     private String location;
 
+    @NotBlank(message = "체류 장소 주소를 입력해주세요.")
+    @Size(max = 30, message = "체류 장소 주소는 최대 30자입니다.")
+    private String roadAddress;
+
     @NotNull(message = "체류 장소 도착 시간을 입력해주세요.")
     private String arrivalDateTime;
 

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/save/StaySaveRequest.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/save/StaySaveRequest.java
@@ -19,8 +19,8 @@ public class StaySaveRequest extends ItinerarySaveRequest {
     private String location;
 
     @NotBlank(message = "체류 장소 주소를 입력해주세요.")
-    @Size(max = 30, message = "체류 장소 주소는 최대 30자입니다.")
-    private String roadAddress;
+    @Size(max = 50, message = "체류 장소 주소는 최대 50자입니다.")
+    private String locationAddress;
 
     @NotNull(message = "체류 장소 도착 시간을 입력해주세요.")
     private String arrivalDateTime;

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/save/TransportSaveRequest.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/save/TransportSaveRequest.java
@@ -22,16 +22,16 @@ public class TransportSaveRequest extends ItinerarySaveRequest {
     private String departureLocation;
 
     @NotBlank(message = "출발 장소 주소를 입력해주세요.")
-    @Size(max = 30, message = "출발 장소 주소는 최대 30자입니다.")
-    private String departureRoadAddress;
+    @Size(max = 50, message = "출발 장소 주소는 최대 50자입니다.")
+    private String departureAddress;
 
     @NotBlank(message = "도착 장소를 입력해주세요.")
     @Size(max = 30, message = "도착 장소는 최대 30자입니다.")
     private String arrivalLocation;
 
     @NotBlank(message = "도착 장소 주소를 입력해주세요.")
-    @Size(max = 30, message = "도착 장소 주소는 최대 30자입니다.")
-    private String arrivalRoadAddress;
+    @Size(max = 50, message = "도착 장소 주소는 최대 50자입니다.")
+    private String arrivalAddress;
 
     @NotNull(message = "출발 시간을 입력해주세요.")
     private String departureDateTime;

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/save/TransportSaveRequest.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/save/TransportSaveRequest.java
@@ -21,9 +21,17 @@ public class TransportSaveRequest extends ItinerarySaveRequest {
     @Size(max = 30, message = "출발 장소는 최대 30자입니다.")
     private String departureLocation;
 
+    @NotBlank(message = "출발 장소 주소를 입력해주세요.")
+    @Size(max = 30, message = "출발 장소 주소는 최대 30자입니다.")
+    private String departureRoadAddress;
+
     @NotBlank(message = "도착 장소를 입력해주세요.")
     @Size(max = 30, message = "도착 장소는 최대 30자입니다.")
     private String arrivalLocation;
+
+    @NotBlank(message = "도착 장소 주소를 입력해주세요.")
+    @Size(max = 30, message = "도착 장소 주소는 최대 30자입니다.")
+    private String arrivalRoadAddress;
 
     @NotNull(message = "출발 시간을 입력해주세요.")
     private String departureDateTime;

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/update/AccommodationPatchRequest.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/update/AccommodationPatchRequest.java
@@ -2,6 +2,7 @@ package com.example.trip_itinerary.itinerary.dto.request.update;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,7 +13,12 @@ import lombok.Setter;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class AccommodationPatchRequest extends ItineraryPatchRequest {
 
+    @Size(max = 30, message = "숙소 이름은 최대 30자입니다.")
     private String accommodationName;
+
+    @Size(max = 30, message = "체류 장소는 최대 30자입니다.")
+    private String roadAddress;
+
     private String checkInTime;
     private String checkOutTime;
 

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/update/AccommodationPatchRequest.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/update/AccommodationPatchRequest.java
@@ -16,8 +16,8 @@ public class AccommodationPatchRequest extends ItineraryPatchRequest {
     @Size(max = 30, message = "숙소 이름은 최대 30자입니다.")
     private String accommodationName;
 
-    @Size(max = 30, message = "체류 장소는 최대 30자입니다.")
-    private String roadAddress;
+    @Size(max = 50, message = "숙소 주소는 최대 50자입니다.")
+    private String accommodationAddress;
 
     private String checkInTime;
     private String checkOutTime;

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/update/StayPatchRequest.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/update/StayPatchRequest.java
@@ -16,8 +16,8 @@ public class StayPatchRequest extends ItineraryPatchRequest {
     @Size(max = 30, message = "체류 장소는 최대 30자입니다.")
     private String location;
 
-    @Size(max = 30, message = "체류 장소 주소는 최대 30자입니다.")
-    private String roadAddress;
+    @Size(max = 50, message = "체류 장소 주소는 최대 50자입니다.")
+    private String locationAddress;
 
     private String arrivalDateTime;
     private String leaveDateTime;

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/update/StayPatchRequest.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/update/StayPatchRequest.java
@@ -15,6 +15,10 @@ public class StayPatchRequest extends ItineraryPatchRequest {
 
     @Size(max = 30, message = "체류 장소는 최대 30자입니다.")
     private String location;
+
+    @Size(max = 30, message = "체류 장소 주소는 최대 30자입니다.")
+    private String roadAddress;
+
     private String arrivalDateTime;
     private String leaveDateTime;
 

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/update/TransportPatchRequest.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/update/TransportPatchRequest.java
@@ -19,14 +19,14 @@ public class TransportPatchRequest extends ItineraryPatchRequest {
     @Size(max = 30, message = "출발 장소는 최대 30자입니다.")
     private String departureLocation;
 
-    @Size(max = 30, message = "출발 주소는 최대 30자입니다.")
-    private String departureRoadAddress;
+    @Size(max = 50, message = "출발 주소는 최대 50자입니다.")
+    private String departureAddress;
 
     @Size(max = 30, message = "도착 장소는 최대 30자입니다.")
     private String arrivalLocation;
 
-    @Size(max = 30, message = "도착 주소는 최대 30자입니다.")
-    private String arrivalRoadAddress;
+    @Size(max = 50, message = "도착 주소는 최대 50자입니다.")
+    private String arrivalAddress;
 
     private String departureDateTime;
     private String arrivalDateTime;

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/update/TransportPatchRequest.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/request/update/TransportPatchRequest.java
@@ -15,10 +15,19 @@ public class TransportPatchRequest extends ItineraryPatchRequest {
 
     @Size(max = 30, message = "이동 방법은 최대 30자입니다.")
     private String transportation;
+
     @Size(max = 30, message = "출발 장소는 최대 30자입니다.")
     private String departureLocation;
+
+    @Size(max = 30, message = "출발 주소는 최대 30자입니다.")
+    private String departureRoadAddress;
+
     @Size(max = 30, message = "도착 장소는 최대 30자입니다.")
     private String arrivalLocation;
+
+    @Size(max = 30, message = "도착 주소는 최대 30자입니다.")
+    private String arrivalRoadAddress;
+
     private String departureDateTime;
     private String arrivalDateTime;
 

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/response/ItineraryFindResponse.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/response/ItineraryFindResponse.java
@@ -23,11 +23,11 @@ ItineraryFindResponse {
 
     private String departureLocation;
 
-    private String departureRoadAddress;
+    private String departureAddress;
 
     private String arrivalLocation;
 
-    private String arrivalRoadAddress;
+    private String arrivalAddress;
 
     private LocalDateTime departureDateTime;
 
@@ -37,7 +37,7 @@ ItineraryFindResponse {
 
     private String accommodationName;
 
-    private String accommodationRoadAddress;
+    private String accommodationAddress;
 
     private LocalDateTime checkInTime;
 
@@ -45,16 +45,16 @@ ItineraryFindResponse {
 
     private String location;
 
-    private String locationRoadAddress;
+    private String locationAddress;
 
     public static ItineraryFindResponse fromEntity(Transport transport) {
         return ItineraryFindResponse.builder()
                 .name(transport.getName())
                 .transportation(transport.getTransportation())
                 .departureLocation(transport.getDepartureLocation())
-                .departureRoadAddress(transport.getDepartureRoadAddress())
+                .departureAddress(transport.getDepartureAddress())
                 .arrivalLocation(transport.getArrivalLocation())
-                .arrivalRoadAddress(transport.getArrivalRoadAddress())
+                .arrivalAddress(transport.getArrivalAddress())
                 .departureDateTime(transport.getDepartureDateTime())
                 .arrivalDateTime(transport.getArrivalDateTime())
                 .build();
@@ -64,7 +64,7 @@ ItineraryFindResponse {
         return ItineraryFindResponse.builder()
                 .name(accommodation.getName())
                 .accommodationName(accommodation.getName())
-                .accommodationRoadAddress(accommodation.getRoadAddress())
+                .accommodationAddress(accommodation.getAccommodationAddress())
                 .checkInTime(accommodation.getCheckInTime())
                 .checkOutTime(accommodation.getCheckOutTime())
                 .build();
@@ -74,7 +74,7 @@ ItineraryFindResponse {
         return ItineraryFindResponse.builder()
                 .name(stay.getName())
                 .location(stay.getLocation())
-                .locationRoadAddress(stay.getRoadAddress())
+                .locationAddress(stay.getLocationAddress())
                 .arrivalDateTime(stay.getArrivalDateTime())
                 .leaveDateTime(stay.getLeaveDateTime())
                 .build();

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/response/ItineraryFindResponse.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/response/ItineraryFindResponse.java
@@ -23,7 +23,11 @@ ItineraryFindResponse {
 
     private String departureLocation;
 
+    private String departureRoadAddress;
+
     private String arrivalLocation;
+
+    private String arrivalRoadAddress;
 
     private LocalDateTime departureDateTime;
 
@@ -33,18 +37,24 @@ ItineraryFindResponse {
 
     private String accommodationName;
 
+    private String accommodationRoadAddress;
+
     private LocalDateTime checkInTime;
 
     private LocalDateTime checkOutTime;
 
     private String location;
 
+    private String locationRoadAddress;
+
     public static ItineraryFindResponse fromEntity(Transport transport) {
         return ItineraryFindResponse.builder()
                 .name(transport.getName())
                 .transportation(transport.getTransportation())
                 .departureLocation(transport.getDepartureLocation())
+                .departureRoadAddress(transport.getDepartureRoadAddress())
                 .arrivalLocation(transport.getArrivalLocation())
+                .arrivalRoadAddress(transport.getArrivalRoadAddress())
                 .departureDateTime(transport.getDepartureDateTime())
                 .arrivalDateTime(transport.getArrivalDateTime())
                 .build();
@@ -54,6 +64,7 @@ ItineraryFindResponse {
         return ItineraryFindResponse.builder()
                 .name(accommodation.getName())
                 .accommodationName(accommodation.getName())
+                .accommodationRoadAddress(accommodation.getRoadAddress())
                 .checkInTime(accommodation.getCheckInTime())
                 .checkOutTime(accommodation.getCheckOutTime())
                 .build();
@@ -63,6 +74,7 @@ ItineraryFindResponse {
         return ItineraryFindResponse.builder()
                 .name(stay.getName())
                 .location(stay.getLocation())
+                .locationRoadAddress(stay.getRoadAddress())
                 .arrivalDateTime(stay.getArrivalDateTime())
                 .leaveDateTime(stay.getLeaveDateTime())
                 .build();

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/response/KakaoAddressResponse.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/dto/response/KakaoAddressResponse.java
@@ -1,0 +1,14 @@
+package com.example.trip_itinerary.itinerary.dto.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class KakaoAddressResponse {
+    private List<String> roadAddressNames;
+}

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/service/KakaoApiService.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/service/KakaoApiService.java
@@ -64,6 +64,6 @@ public class KakaoApiService {
         } catch (Exception e) {
             e.printStackTrace();
         }
-
+        return null;
     }
 }

--- a/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/service/KakaoApiService.java
+++ b/trip_itinerary/src/main/java/com/example/trip_itinerary/itinerary/service/KakaoApiService.java
@@ -1,0 +1,69 @@
+package com.example.trip_itinerary.itinerary.service;
+
+import com.example.trip_itinerary.itinerary.dto.response.KakaoAddressResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Service
+public class KakaoApiService {
+    @Value("${kakao.api.key}")
+    private String kakaoApiKey;
+    @Value("${kakao.url.keyword}")
+    private String kakaoUrl;
+
+    private final RestTemplate restTemplate;
+
+    public KakaoApiService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public KakaoAddressResponse getAddressFromKakao(String query) {
+        try {
+            String encodedQuery = URLEncoder.encode(query, StandardCharsets.UTF_8);
+            URI url = UriComponentsBuilder.fromUriString(kakaoUrl)
+                    .queryParam("query", encodedQuery)
+                    .build()
+                    .toUri();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "KakaoAK " + kakaoApiKey);
+
+            RequestEntity<Void> requestEntity = RequestEntity.get(url).headers(headers).build();
+
+            ResponseEntity<String> responseEntity = restTemplate.exchange(requestEntity, String.class);
+
+            if (responseEntity.getStatusCode().is2xxSuccessful()) {
+                String responseBody = responseEntity.getBody();
+
+                ObjectMapper objectMapper = new ObjectMapper();
+                JsonNode rootNode = objectMapper.readTree(responseBody);
+
+                List<String> roadAddressNames = objectMapper.convertValue(
+                        rootNode.path("documents").findValuesAsText("road_address_name"),
+                        List.class
+                );
+
+                KakaoAddressResponse addressResponse = new KakaoAddressResponse();
+                addressResponse.setRoadAddressNames(roadAddressNames);
+
+                return addressResponse;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+    }
+}

--- a/trip_itinerary/src/main/resources/application.yml
+++ b/trip_itinerary/src/main/resources/application.yml
@@ -19,3 +19,11 @@ spring:
     username: root
     password: root
     driver-class-name: com.mysql.cj.jdbc.Driver
+
+kakao:
+  api:
+    key: de85ce8610b9303252cedfbe5cbad650
+  url:
+    address: https://dapi.kakao.com/v2/local/search/
+    keyword: https://dapi.kakao.com/v2/local/search/keyword
+  query: ?query=

--- a/trip_itinerary/src/main/resources/application.yml
+++ b/trip_itinerary/src/main/resources/application.yml
@@ -19,11 +19,3 @@ spring:
     username: root
     password: root
     driver-class-name: com.mysql.cj.jdbc.Driver
-
-kakao:
-  api:
-    key: de85ce8610b9303252cedfbe5cbad650
-  url:
-    address: https://dapi.kakao.com/v2/local/search/
-    keyword: https://dapi.kakao.com/v2/local/search/keyword
-  query: ?query=


### PR DESCRIPTION
## 목적
카카오 API로 상세주소 전달기능 추가

## 로직 설명
1. 사용자가 여정의 저장,수정의 최종요청을 보내기 전에 주소란을 채우기 위해 키워드로 상세주소 검색을 요청.
   - 우리가 수정 요청이 오기 전에 GET요청으로 사용자가 먼저 정보를 받은 것을 가정했듯 주소란을 채우기 위해 먼저 유저의 키워드로 상세주소를 받아 채우는 행동을 먼저 한다고 가정.
3. 사용자의 키워드 String을 받아 카카오API에 키워드 검색 후 상위 10개 결과 중 도로명 주소 항목들을 List<String>으로 묶어 해당 멤버를 가지고 있는  KakaoAddressResponse로 반환
4. 사용자가 가져온 도로명 주소를 합하여 여정의 저장, 수정 요청

## 핵심 변경사항
### 각 Stay, Accommodation, Transport 여정들 중 장소 멤버들은 도로명 주소 컬럼까지 추가.
  Stay - location이 있으므로 roadAddress 추가, 
  Accommodation - accommodation이 있으므로 roadAddress 추가,
  Transport - departureLocation이 있으므로 departureRoadAddress 추가, arrivalLocation이 있으므로 arrivalRoadAddress 추가

### ItineraryController에 getAddressByNameFromKakao 메서드 추가
### ItineraryService에서 호출하는 KakaoApiService 추가
### KakaoAddressResponse 추가

## 특이 사항 
임시로 GetMapping의 주소를 /address로 하고 쿼리로 키워드를 받았음.
예외처리도 임시로 하였음.

## Issue Link - #22 